### PR TITLE
Fix shift_window parameter in swin_unet_2d()

### DIFF
--- a/examples/user_guide_models.ipynb
+++ b/examples/user_guide_models.ipynb
@@ -78,9 +78,9 @@
    "source": [
     "Commonly used hyper-parameter options are listed as follows. Full details are available through the Python helper function:\n",
     "\n",
-    "* `inpust_size`: a tuple or list that defines the shape of input tensors. \n",
-    "    * `models.resunet_a_2d`, `models.transunet_2d`, and `models.swin_unet_2d` support int only, others also support `inpust_size=(None, None, 3)`.\n",
-    "    * `activation='PReLU'` is not compatible with `inpust_size=(None, None, 3)`. \n",
+    "* `input_size`: a tuple or list that defines the shape of input tensors. \n",
+    "    * `models.resunet_a_2d`, `models.transunet_2d`, and `models.swin_unet_2d` support int only, others also support `input_size=(None, None, 3)`.\n",
+    "    * `activation='PReLU'` is not compatible with `input_size=(None, None, 3)`. \n",
     "\n",
     "\n",
     "* `filter_num`: a list that defines the number of convolutional filters per down- and up-sampling blocks.\n",

--- a/keras_unet_collection/_model_swin_unet_2d.py
+++ b/keras_unet_collection/_model_swin_unet_2d.py
@@ -228,7 +228,7 @@ def swin_unet_2d(input_size, filter_num_begin, n_labels, depth, stack_num_down, 
     
     # base    
     X = swin_unet_2d_base(IN, filter_num_begin=filter_num_begin, depth=depth, stack_num_down=stack_num_down, stack_num_up=stack_num_up, 
-                          patch_size=patch_size, num_heads=num_heads, window_size=window_size, num_mlp=num_mlp, shift_window=True, name=name)
+                          patch_size=patch_size, num_heads=num_heads, window_size=window_size, num_mlp=num_mlp, shift_window=shift_window, name=name)
     
     # output layer
     OUT = CONV_output(X, n_labels, kernel_size=1, activation=output_activation, name='{}_output'.format(name))


### PR DESCRIPTION
The `shift_window` parameter in `swin_unet_2d()` was not passed to `swin_unet_2d_base()`